### PR TITLE
Use basepom-oss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
 
     <parent>
         <groupId>org.basepom</groupId>
-        <artifactId>basepom-foundation</artifactId>
-        <version>16</version>
+        <artifactId>basepom-oss</artifactId>
+        <version>18</version>
     </parent>
 
     <properties>
@@ -75,6 +75,7 @@
         <basepom.release.push-changes>true</basepom.release.push-changes>
         <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
         <basepom.check.fail-findbugs>false</basepom.check.fail-findbugs>
+        <basepom.oss.skip-scala-doc>false</basepom.oss.skip-scala-doc>
         <project.build.targetJdk>1.7</project.build.targetJdk>
     </properties>
 
@@ -174,6 +175,29 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/pom.xml</exclude>
+                            <exclude>**/scalastyle_config.xml</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${dep.plugin.release.version}</version>
+                    <configuration>
+                        <useReleaseProfile>true</useReleaseProfile>
+                        <releaseProfiles>basepom.oss-release</releaseProfiles>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencies>


### PR DESCRIPTION
Use `basepom-oss` instead of `basepom-foundation`, which includes additional steps required for releasing to Maven central. This also be default now uses the `basepom.oss-release` profile included with `basepom-oss`. With these changes, a staging build is set up on the public Nexus instance with the following commands:
```shell
mvn release:clean release:prepare
mvn release:perform
```

After the checks on the Nexus staging repository pass, then we can finally perform a public release.

The other requirement for performing a release is to have the `gpg` library installed locally. The full detailed steps are [listed here](http://central.sonatype.org/pages/working-with-pgp-signatures.html). For Homebrew users on OSX, this can just be installed with `brew install gpg`. After that, a new key pair needs to be created, and the public key needs to be distributed in order for the checks on Nexus to pass. 

The Maven `settings.xml` file local to your machine also needs to be modified for this release process. Credientials for your Sonatype account should be added under `servers`:
```xml
  <servers>

   <!-- other servers ... -->

    <server>
      <id>ossrh</id>
      <username>${sonatype_username}</username>
      <password>${sonatype_password}</password>
    </server>
  </servers>

```

Information about the GPG key pair also need to be added under the `profiles` section:
```xml
  <profiles>

  <!-- other profiles ... -->

    <profile>
      <id>ossrh</id>
      <activation>
        <activeByDefault>true</activeByDefault>
      </activation>
      <properties>
        <gpg.executable>gpg</gpg.executable>
        <gpg.passphrase>${gpg_password}</gpg.passphrase>
      </properties>
    </profile>
  </profiles>
```