### PR TITLE
Make Spark 2.0 the default version supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,35 @@
 
 A library to expose more of [Apache Spark](http://spark.apache.org/)'s metrics system. This library allows you to use APIs like the [Dropwizard/Codahale Metrics](http://metrics.dropwizard.io/3.1.0/) library on Spark applications to publish metrics that are aggregated across all executors.
 
-
 ## Dependencies
-To use this library, add a dependency to `spark-metrics` in your project:
+
+### Spark 2.x
+`spark-metrics` by default will be targeting the Spark 2.x line of releases. To use this library for a Spark 2.x application, add the following dependency:
+
 ```xml
 <dependency>
     <groupId>com.groupon.dse</groupId>
     <artifactId>spark-metrics</artifactId>
-    <version>1.0</version>
+    <version>2.0.0</version>
 </dependency>
 ```
 
-This library is currently built for **Spark 1.5.2**, but is also compatible with 1.4.1. This is important to note because this library uses Spark's internal APIs, and compatibility with other major Spark versions has not been fully tested.
+Note that `spark-metrics` targets Scala 2.11 by default, as that is the default Scala version supported by Spark 2.x. To support Scala 2.10 on the Spark 2.x releases, this library will need to be recompiled with the Spark dependencies that target Scala 2.10.
 
+### Spark 1.x
+To use this library with the Spark 1.x line of releases, add a dependency to `spark-metrics_spark-1.x` instead:
+
+```xml
+<dependency>
+    <groupId>com.groupon.dse</groupId>
+    <artifactId>spark-metrics_spark-1.x</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+The default Spark version targeted for `spark-metrics_spark-1.x` is Spark 1.6.3, but it is compatible with 1.5 and 1.4 as well. Note that `spark-metrics_spark-1.x` targets Scala 2.10 by default, as that is the default Scala version supported by Spark 1.x. To support Scala 2.11 on the Spark 1.x releases, this library will need to be recompiled with the Spark dependencies that target Scala 2.11.
+
+Updates to `spark-metrics` will be backported to `spark-metrics_spark-1.x` whenever possible, but support for `spark-metrics_spark-1.x` will be discontinued at some point in the future.
 
 ## Usage
 Include this import in your main Spark application file:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.groupon.dse</groupId>
     <artifactId>spark-metrics</artifactId>
     <packaging>jar</packaging>
-    <version>1.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A library to expose more of Apache Spark's metrics system</description>
@@ -60,23 +60,23 @@
     <properties>
         <!-- Dependencies -->
         <dropwizard.version>3.1.2</dropwizard.version>
-        <scala.compat.version>2.10</scala.compat.version>
-        <spark.version>1.5.2</spark.version>
+        <scala.compat.version>2.11</scala.compat.version>
+        <spark.version>2.0.1</spark.version>
         <jetty.version>8.1.14.v20131031</jetty.version>
-        <scalatest.version>2.2.4</scalatest.version>
+        <scalatest.version>2.2.6</scalatest.version>
 
         <!-- Plugins -->
         <dep.plugin.scalatest-maven-plugin.version>1.0</dep.plugin.scalatest-maven-plugin.version>
         <dep.plugin.scalastyle-maven-plugin.version>0.6.0</dep.plugin.scalastyle-maven-plugin.version>
 
         <!-- Basepom Overrides -->
-        <dep.scala.version>2.10.4</dep.scala.version>
+        <dep.scala.version>2.11.8</dep.scala.version>
         <dep.plugin.scala.version>3.2.2</dep.plugin.scala.version>
         <basepom.release.push-changes>true</basepom.release.push-changes>
         <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
         <basepom.check.fail-findbugs>false</basepom.check.fail-findbugs>
         <basepom.oss.skip-scala-doc>false</basepom.oss.skip-scala-doc>
-        <project.build.targetJdk>1.7</project.build.targetJdk>
+        <project.build.targetJdk>1.8</project.build.targetJdk>
     </properties>
 
     <build>
@@ -206,12 +206,6 @@
             <artifactId>metrics-core</artifactId>
             <version>${dropwizard.version}</version>
             <exclusions>
-                <!--
-                [ERROR] Found a problem with the dependency org.slf4j:slf4j-api
-                  Resolved version is 1.7.7
-                  Version 1.7.10 was expected by artifacts: org.apache.spark:spark-core_2.10, org.apache.spark:spark-streaming_2.10
-                  Version 1.7.7 was expected by artifact: io.dropwizard.metrics:metrics-core
-                -->
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
@@ -221,16 +215,17 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.10</artifactId>
+            <artifactId>spark-core_2.11</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming_2.10</artifactId>
+            <artifactId>spark-streaming_2.11</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
@@ -259,9 +254,15 @@
 
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.10</artifactId>
-            <version>${scalatest.version}</version>
+            <artifactId>scalatest_2.11</artifactId>
             <scope>test</scope>
+            <version>${scalatest.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-reflect</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
@@ -167,7 +167,7 @@ private[metrics] class MetricsReceiver(val sparkContext: SparkContext,
    * @param metric [[Metric]] instance to be published
    */
   def registerMetricSource(metricName: String, metric: Metric): Unit =  {
-    sparkContext.metricsSystem.registerSource(
+    sparkContext.env.metricsSystem.registerSource(
       new Source {
         override val sourceName = s"${sparkContext.appName}.$metricNamespace"
         override def metricRegistry: MetricRegistry = {


### PR DESCRIPTION
Adding support for Spark 2.0 and making it the default Spark version targeted by this library.

Going forward, this is the way I think the library would be maintained:

* `com.groupon.dse:spark-metrics` artifact will be the "canonical" version of this library. It will target Spark 2.x releases with Scala 2.11 and will try to stay as up-to-date as possible with the latest Spark releases. This will live on the `master` branch.
* `com.groupon.dse:spark-metrics_spark-1.x` artifact will target Spark 1.x releases with Scala 2.10. The latest 1.x release is Spark 1.6.3 and, as far as I know, there are only going to be bug fix releases for Spark 1.x going forward. This will live on the `spark-1.x` branch, and updates will be back-ported from `master` whenever possible. Support for `com.groupon.dse:spark-metrics_spark-1.x` would be dropped sometime in the future.

Also going forward we'll try to stick to semver, so the next version to release is going to be 2.0.0

@uditmehta27 what do you think about this? @erikdw I'd like to get your opinion on this too, since this seems sort of similar to what you're doing on https://github.com/mesos/storm