### PR TITLE
Metrics Receiver: Thread safety issue (critical for me, please merge)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.groupon.dse</groupId>
     <artifactId>spark-metrics</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A library to expose more of Apache Spark's metrics system</description>
@@ -37,7 +37,7 @@
         <connection>scm:git:git@github.com:groupon/spark-metrics.git</connection>
         <developerConnection>scm:git:git@github.com:groupon/spark-metrics.git</developerConnection>
         <url>https://github.com/groupon/spark-metrics</url>
-        <tag>spark-metrics-2.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.groupon.dse</groupId>
     <artifactId>spark-metrics</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A library to expose more of Apache Spark's metrics system</description>
@@ -37,7 +37,7 @@
         <connection>scm:git:git@github.com:groupon/spark-metrics.git</connection>
         <developerConnection>scm:git:git@github.com:groupon/spark-metrics.git</developerConnection>
         <url>https://github.com/groupon/spark-metrics</url>
-        <tag>HEAD</tag>
+        <tag>spark-metrics-2.0.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Hello,

I have started using spark-metrics lib, but it appeared that SparkMetrics.getOrCreateCounter, getOrCreateHistogram etc. are not thread safe. There might be a case when multiple executors are sending metrics messages w/ the same metric name and MetricsReceiver starts processing multiple metrics registration requests in parallel. As a result, metrics.getOrElseUpdate might start constructing multiple values for the same metric key in parallel. At the end of the day, requests for the same metric make it to MetricsSystem.registerSource in parallel and I am getting an error which leads to a broken counter i.e. a counter which isn't being tracked.

This is the example of the exception I am seeing in logs:

17/03/15 18:32:19 INFO metrics.MetricsSystem: Metrics already registered
java.lang.IllegalArgumentException: A metric named 370b7dd5-e97f-4d83-8b4e-c1aa3e4486d7-8972.driver.outCount already exists
    at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:91)
    at com.codahale.metrics.MetricRegistry.registerAll(MetricRegistry.java:389)
    at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:85)
    at org.apache.spark.metrics.MetricsSystem.registerSource(MetricsSystem.scala:152)
    at org.apache.spark.groupon.metrics.MetricsReceiver.registerMetricSource(MetricsReceiver.scala:170)
    at org.apache.spark.groupon.metrics.MetricsReceiver$$anonfun$getOrCreateCounter$1.apply(MetricsReceiver.scala:118)
    at org.apache.spark.groupon.metrics.MetricsReceiver$$anonfun$getOrCreateCounter$1.apply(MetricsReceiver.scala:116)
    at scala.collection.mutable.MapLike$class.getOrElseUpdate(MapLike.scala:189)
    at scala.collection.mutable.AbstractMap.getOrElseUpdate(Map.scala:91)
    at org.apache.spark.groupon.metrics.MetricsReceiver.getOrCreateCounter(MetricsReceiver.scala:116)
    at org.apache.spark.groupon.metrics.MetricsReceiver$$anonfun$receive$1.applyOrElse(MetricsReceiver.scala:97)
    at org.apache.spark.rpc.netty.Inbox$$anonfun$process$1.apply$mcV$sp(Inbox.scala:116)
    at org.apache.spark.rpc.netty.Inbox.safelyCall(Inbox.scala:204)
    at org.apache.spark.rpc.netty.Inbox.process(Inbox.scala:100)
    at org.apache.spark.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:215)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)

The PR I am submitting fixes the issue and was tested by me.