### PR TITLE
Metrics Receiver: thread safety issue on metrics registration (critical, please merge)

### DIFF
--- a/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
@@ -114,45 +114,65 @@ private[metrics] class MetricsReceiver(val sparkContext: SparkContext,
 
   def getOrCreateCounter(metricName: String): Counter = {
     metrics.getOrElseUpdate(metricName, {
-      val counter = new Counter()
-      registerMetricSource(metricName, counter)
-      counter
+      metrics.synchronized {
+        metrics.getOrElse(metricName,{
+          val counter = new Counter()
+          registerMetricSource(metricName, counter)
+          counter
+        })
+      }
     }).asInstanceOf[Counter]
   }
 
   def getOrCreateHistogram(metricName: String, reservoirClass: Class[_ <: Reservoir]): Histogram = {
     metrics.getOrElseUpdate(metricName, {
-      val histogram = new Histogram(reservoirClass.newInstance())
-      registerMetricSource(metricName, histogram)
-      histogram
+      metrics.synchronized {
+        metrics.getOrElse(metricName, {
+          val histogram = new Histogram(reservoirClass.newInstance())
+          registerMetricSource(metricName, histogram)
+          histogram
+        })
+      }
     }).asInstanceOf[Histogram]
   }
 
   def getOrCreateMeter(metricName: String): Meter = {
     metrics.getOrElseUpdate(metricName, {
-      val meter = new Meter()
-      registerMetricSource(metricName, meter)
-      meter
+      metrics.synchronized {
+        metrics.getOrElse(metricName, {
+          val meter = new Meter()
+          registerMetricSource(metricName, meter)
+          meter
+        })
+      }
     }).asInstanceOf[Meter]
   }
 
   def getOrCreateTimer(metricName: String, reservoirClass: Class[_ <: Reservoir], clockClass: Class[_ <: Clock]): Timer = {
     metrics.getOrElseUpdate(metricName, {
-      val timer = new Timer(reservoirClass.newInstance(), clockClass.newInstance())
-      registerMetricSource(metricName, timer)
-      timer
+      metrics.synchronized {
+        metrics.getOrElse(metricName, {
+          val timer = new Timer(reservoirClass.newInstance(), clockClass.newInstance())
+          registerMetricSource(metricName, timer)
+          timer
+        })
+      }
     }).asInstanceOf[Timer]
   }
 
   def getOrCreateGauge(metricName: String): Gauge[AnyVal] = {
     metrics.getOrElseUpdate(metricName, {
-      val gauge = new Gauge[AnyVal] {
-        override def getValue: AnyVal = {
-          lastGaugeValues.get(metricName).get
-        }
+      metrics.synchronized {
+        metrics.getOrElse(metricName, {
+          val gauge = new Gauge[AnyVal] {
+            override def getValue: AnyVal = {
+              lastGaugeValues(metricName)
+            }
+          }
+          registerMetricSource(metricName, gauge)
+          gauge
+        })
       }
-      registerMetricSource(metricName, gauge)
-      gauge
     }).asInstanceOf[Gauge[AnyVal]]
   }
 


### PR DESCRIPTION
Hello,

I have started using spark-metrics lib, but it appeared that SparkMetrics.getOrCreateCounter, getOrCreateHistogram etc. are not thread safe. There might be a case when multiple executors are sending metrics messages w/ the same metric name and MetricsReceiver starts processing multiple metrics registration requests in parallel. As a result, metrics.getOrElseUpdate might start constructing multiple values for the same metric key in parallel. At the end of the day, requests for the same metric make it to MetricsSystem.registerSource in parallel and I am getting an error which leads to a broken counter i.e. a counter which isn't being tracked.

This is the example of the exception I am seeing in logs:

17/03/15 18:32:19 INFO metrics.MetricsSystem: Metrics already registered
java.lang.IllegalArgumentException: A metric named 370b7dd5-e97f-4d83-8b4e-c1aa3e4486d7-8972.driver.outCount already exists
at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:91)
at com.codahale.metrics.MetricRegistry.registerAll(MetricRegistry.java:389)
at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:85)
at org.apache.spark.metrics.MetricsSystem.registerSource(MetricsSystem.scala:152)
at org.apache.spark.groupon.metrics.MetricsReceiver.registerMetricSource(MetricsReceiver.scala:170)
at org.apache.spark.groupon.metrics.MetricsReceiver$$anonfun$getOrCreateCounter$1.apply(MetricsReceiver.scala:118)
at org.apache.spark.groupon.metrics.MetricsReceiver$$anonfun$getOrCreateCounter$1.apply(MetricsReceiver.scala:116)
at scala.collection.mutable.MapLike$class.getOrElseUpdate(MapLike.scala:189)
at scala.collection.mutable.AbstractMap.getOrElseUpdate(Map.scala:91)
at org.apache.spark.groupon.metrics.MetricsReceiver.getOrCreateCounter(MetricsReceiver.scala:116)
at org.apache.spark.groupon.metrics.MetricsReceiver$$anonfun$receive$1.applyOrElse(MetricsReceiver.scala:97)
at org.apache.spark.rpc.netty.Inbox$$anonfun$process$1.apply$mcV$sp(Inbox.scala:116)
at org.apache.spark.rpc.netty.Inbox.safelyCall(Inbox.scala:204)
at org.apache.spark.rpc.netty.Inbox.process(Inbox.scala:100)
at org.apache.spark.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:215)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
at java.lang.Thread.run(Thread.java:745)

The PR I am submitting fixes the issue and was tested by me.