### PR TITLE
Fixed "Metrics already registered" issue

### DIFF
--- a/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/MetricsReceiver.scala
@@ -34,13 +34,11 @@ package org.apache.spark.groupon.metrics
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.function
 
 import com.codahale.metrics.{Clock, Counter, Gauge, Histogram, Meter, Metric, MetricRegistry, Reservoir, Timer}
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.rpc.RpcEndpoint
-
-import scala.collection.concurrent
-import scala.collection.JavaConverters.mapAsScalaConcurrentMapConverter
+import org.apache.spark.rpc.{RpcEndpoint, RpcEnv}
 
 /**
  * MetricsReceiver is an [[RpcEndpoint]] on the driver node that collects data points for metrics from all the executors
@@ -79,12 +77,12 @@ import scala.collection.JavaConverters.mapAsScalaConcurrentMapConverter
  */
 private[metrics] class MetricsReceiver(val sparkContext: SparkContext,
                                        val metricNamespace: String) extends RpcEndpoint {
-  override val rpcEnv = sparkContext.env.rpcEnv
+  override val rpcEnv: RpcEnv = sparkContext.env.rpcEnv
 
   // Tracks the last observed value for each Gauge
-  val lastGaugeValues: concurrent.Map[String, AnyVal] = new ConcurrentHashMap[String, AnyVal]().asScala
+  val lastGaugeValues: ConcurrentHashMap[String, AnyVal] = new ConcurrentHashMap[String, AnyVal]()
   // Keeps track of all the Metric instances that are being published
-  val metrics: concurrent.Map[String, Metric] = new ConcurrentHashMap[String, Metric]().asScala
+  val metrics: ConcurrentHashMap[String, Metric] = new ConcurrentHashMap[String, Metric]()
 
   /**
    * Handle the data points pushed from the executors.
@@ -93,67 +91,57 @@ private[metrics] class MetricsReceiver(val sparkContext: SparkContext,
    * time, a [[Metric]] instance is created using the data from the [[MetricMessage]].
    */
   override def receive: PartialFunction[Any, Unit] = {
-    case CounterMessage(metricName, value) => {
+    case CounterMessage(metricName, value) =>
       getOrCreateCounter(metricName).inc(value)
-    }
-    case HistogramMessage(metricName, value, reservoirClass) => {
+    case HistogramMessage(metricName, value, reservoirClass) =>
       getOrCreateHistogram(metricName, reservoirClass).update(value)
-    }
-    case MeterMessage(metricName, value) => {
+    case MeterMessage(metricName, value) =>
       getOrCreateMeter(metricName).mark(value)
-    }
-    case TimerMessage(metricName, value, reservoirClass, clockClass) => {
+    case TimerMessage(metricName, value, reservoirClass, clockClass) =>
       getOrCreateTimer(metricName, reservoirClass, clockClass).update(value, MetricsReceiver.DefaultTimeUnit)
-    }
-    case GaugeMessage(metricName, value) => {
+    case GaugeMessage(metricName, value) =>
       lastGaugeValues.put(metricName, value)
       getOrCreateGauge(metricName)
-    }
     case message: Any => throw new SparkException(s"$self does not implement 'receive' for message: $message")
   }
 
-  def getOrCreateCounter(metricName: String): Counter = {
-    metrics.getOrElseUpdate(metricName, {
-      val counter = new Counter()
-      registerMetricSource(metricName, counter)
-      counter
-    }).asInstanceOf[Counter]
+  def compute[T <: Metric](metricName: String, newMetric: => T): java.util.function.Function[String, Metric] = new function.Function[String, Metric] {
+    override def apply(t: String): Metric = {
+      registerMetricSource(metricName, newMetric)
+      newMetric
+    }
   }
 
-  def getOrCreateHistogram(metricName: String, reservoirClass: Class[_ <: Reservoir]): Histogram = {
-    metrics.getOrElseUpdate(metricName, {
-      val histogram = new Histogram(reservoirClass.newInstance())
-      registerMetricSource(metricName, histogram)
-      histogram
-    }).asInstanceOf[Histogram]
-  }
+  def getOrCreateCounter(metricName: String): Counter =
+    metrics.computeIfAbsent(metricName, compute(metricName, new Counter)
+    ).asInstanceOf[Counter]
 
-  def getOrCreateMeter(metricName: String): Meter = {
-    metrics.getOrElseUpdate(metricName, {
-      val meter = new Meter()
-      registerMetricSource(metricName, meter)
-      meter
-    }).asInstanceOf[Meter]
-  }
 
-  def getOrCreateTimer(metricName: String, reservoirClass: Class[_ <: Reservoir], clockClass: Class[_ <: Clock]): Timer = {
-    metrics.getOrElseUpdate(metricName, {
-      val timer = new Timer(reservoirClass.newInstance(), clockClass.newInstance())
-      registerMetricSource(metricName, timer)
-      timer
-    }).asInstanceOf[Timer]
-  }
+  def getOrCreateHistogram(metricName: String, reservoirClass: Class[_ <: Reservoir]): Histogram =
+    metrics.computeIfAbsent(
+      metricName,
+      compute(metricName, new Histogram(reservoirClass.newInstance()))
+    ).asInstanceOf[Histogram]
+
+
+  def getOrCreateMeter(metricName: String): Meter =
+    metrics.computeIfAbsent(metricName, compute(metricName, new Meter)
+    ).asInstanceOf[Meter]
+
+
+  def getOrCreateTimer(metricName: String, reservoirClass: Class[_ <: Reservoir], clockClass: Class[_ <: Clock]): Timer =
+    metrics.computeIfAbsent(
+      metricName,
+      compute(metricName, new Timer(reservoirClass.newInstance(), clockClass.newInstance()))
+    ).asInstanceOf[Timer]
 
   def getOrCreateGauge(metricName: String): Gauge[AnyVal] = {
-    metrics.getOrElseUpdate(metricName, {
-      val gauge = new Gauge[AnyVal] {
-        override def getValue: AnyVal = {
-          lastGaugeValues.get(metricName).get
-        }
-      }
-      registerMetricSource(metricName, gauge)
-      gauge
-    }).asInstanceOf[Gauge[AnyVal]]
+    metrics.computeIfAbsent(
+      metricName,
+      compute(metricName, new Gauge[AnyVal] {
+        override def getValue: AnyVal = lastGaugeValues.get(metricName)
+      })
+    ).asInstanceOf[Gauge[AnyVal]]
   }
 
   /**

--- a/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
+++ b/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
@@ -123,13 +123,13 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
 
     eventually {
       metricsReceiver.metrics should contain key counterName
-      metricsReceiver.metrics.get(counterName).get.asInstanceOf[Counter].getCount shouldBe 1
+      metricsReceiver.metrics.get(counterName).asInstanceOf[Counter].getCount shouldBe 1
     }
 
     metricsReceiver.self.send(counterMessage)
 
     eventually {
-      metricsReceiver.metrics.get(counterName).get.asInstanceOf[Counter].getCount shouldBe 2
+      metricsReceiver.metrics.get(counterName).asInstanceOf[Counter].getCount shouldBe 2
     }
   }
 
@@ -140,13 +140,13 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
 
     eventually {
       metricsReceiver.metrics should contain key histogramName
-      metricsReceiver.metrics.get(histogramName).get.asInstanceOf[Histogram].getCount shouldBe 1
+      metricsReceiver.metrics.get(histogramName).asInstanceOf[Histogram].getCount shouldBe 1
     }
 
     metricsReceiver.self.send(histogramMessage)
 
     eventually {
-      metricsReceiver.metrics.get(histogramName).get.asInstanceOf[Histogram].getCount shouldBe 2
+      metricsReceiver.metrics.get(histogramName).asInstanceOf[Histogram].getCount shouldBe 2
     }
   }
 
@@ -157,13 +157,13 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
 
     eventually {
       metricsReceiver.metrics should contain key meterName
-      metricsReceiver.metrics.get(meterName).get.asInstanceOf[Meter].getCount shouldBe 1
+      metricsReceiver.metrics.get(meterName).asInstanceOf[Meter].getCount shouldBe 1
     }
 
     metricsReceiver.self.send(meterMessage)
 
     eventually {
-      metricsReceiver.metrics.get(meterName).get.asInstanceOf[Meter].getCount shouldBe 2
+      metricsReceiver.metrics.get(meterName).asInstanceOf[Meter].getCount shouldBe 2
     }
   }
 
@@ -174,13 +174,13 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
 
     eventually {
       metricsReceiver.metrics should contain key timerName
-      metricsReceiver.metrics.get(timerName).get.asInstanceOf[Timer].getCount shouldBe 1
+      metricsReceiver.metrics.get(timerName).asInstanceOf[Timer].getCount shouldBe 1
     }
 
     metricsReceiver.self.send(timerMessage)
 
     eventually {
-      metricsReceiver.metrics.get(timerName).get.asInstanceOf[Timer].getCount shouldBe 2
+      metricsReceiver.metrics.get(timerName).asInstanceOf[Timer].getCount shouldBe 2
     }
   }
 
@@ -190,13 +190,13 @@ class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter wit
 
     eventually {
       metricsReceiver.metrics should contain key gaugeName
-      metricsReceiver.metrics.get(gaugeName).get.asInstanceOf[Gauge[AnyVal]].getValue shouldBe 1
+      metricsReceiver.metrics.get(gaugeName).asInstanceOf[Gauge[AnyVal]].getValue shouldBe 1
     }
 
     metricsReceiver.self.send(GaugeMessage(gaugeName, 2))
 
     eventually {
-      metricsReceiver.metrics.get(gaugeName).get.asInstanceOf[Gauge[AnyVal]].getValue shouldBe 2
+      metricsReceiver.metrics.get(gaugeName).asInstanceOf[Gauge[AnyVal]].getValue shouldBe 2
     }
   }
 }


### PR DESCRIPTION
Fixed "Metrics already registered" issue by removing the Scala map usage which was not concurrent.
By staying with the java concurrent hash map, one can use compute if absent which is the exact functionality required.
By using call by name I limit the initialization of the actual metric to only when require